### PR TITLE
Add OrderBook

### DIFF
--- a/src/OrderBook.sol
+++ b/src/OrderBook.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
+import '@openzeppelin/contracts/access/Ownable.sol';
+import './SellOrder.sol';
+
+/// @dev A factory for creating orders. The Graph should index this contract.
+contract OrderBook is Ownable {
+    /// @dev emitted when a new sell order is created
+    event SellOrderCreated(address indexed sellOrder);
+
+    /// @dev emitted when setOwner is called
+    event OwnerChanged(address previous, address next);
+
+    /// @dev emitted when setOwner is called
+    event FeeChanged(uint256 previous, uint256 next);
+
+    /// @dev all the sell orders available in the order book
+    mapping(address => bool) public sellOrders;
+
+    /// @dev the fee rate in parts per million
+    uint256 public fee = 10000; // 1%
+
+    /// @dev initializes a new order book
+    constructor() {
+        _transferOwnership(msg.sender);
+    }
+
+    /// @dev changes the fee rate
+    function setFee(uint256 _fee) external onlyOwner {
+        emit FeeChanged(fee, _fee);
+        fee = _fee;
+    }
+
+    /// @dev changes the owner of this order book
+    function setOwner(address _newOwner) external onlyOwner {
+        emit OwnerChanged(owner(), _newOwner);
+        _transferOwnership(_newOwner);
+    }
+
+    /// @dev Creates a new sell order that can be easily indexed by something like theGraph.
+    function createSellOrder(
+        address seller,
+        IERC20 token,
+        uint256 stake,
+        string memory uri,
+        uint256 timeout
+    ) external {
+        SellOrder sellOrder = new SellOrder(
+            this,
+            seller,
+            token,
+            stake,
+            uri,
+            timeout
+        );
+        emit SellOrderCreated(address(sellOrder));
+        sellOrders[address(sellOrder)] = true;
+    }
+}

--- a/src/OrderBook.sol
+++ b/src/OrderBook.sol
@@ -5,18 +5,10 @@ import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 import '@openzeppelin/contracts/access/Ownable.sol';
 import './SellOrder.sol';
+import './interfaces/IOrderBook.sol';
 
 /// @dev A factory for creating orders. The Graph should index this contract.
-contract OrderBook is Ownable {
-    /// @dev emitted when a new sell order is created
-    event SellOrderCreated(address indexed sellOrder);
-
-    /// @dev emitted when setOwner is called
-    event OwnerChanged(address previous, address next);
-
-    /// @dev emitted when setOwner is called
-    event FeeChanged(uint256 previous, uint256 next);
-
+contract OrderBook is Ownable, IOrderBook {
     /// @dev all the sell orders available in the order book
     mapping(address => bool) public sellOrders;
 
@@ -47,16 +39,10 @@ contract OrderBook is Ownable {
         uint256 stake,
         string memory uri,
         uint256 timeout
-    ) external {
-        SellOrder sellOrder = new SellOrder(
-            this,
-            seller,
-            token,
-            stake,
-            uri,
-            timeout
-        );
+    ) external returns (SellOrder) {
+        SellOrder sellOrder = new SellOrder(seller, token, stake, uri, timeout);
         emit SellOrderCreated(address(sellOrder));
         sellOrders[address(sellOrder)] = true;
+        return sellOrder;
     }
 }

--- a/src/OrderBook.sol
+++ b/src/OrderBook.sol
@@ -8,16 +8,39 @@ import './SellOrder.sol';
 import './interfaces/IOrderBook.sol';
 
 /// @dev A factory for creating orders. The Graph should index this contract.
-contract OrderBook is Ownable, IOrderBook {
+contract OrderBook is IOrderBook {
     /// @dev all the sell orders available in the order book
     mapping(address => bool) public sellOrders;
 
     /// @dev the fee rate in parts per million
     uint256 public fee = 10000; // 1%
 
+    /// @dev the authority over this order book, ie the DAO
+    address private _owner;
+
+    /// @dev Throws if msg.sender is not the owner.
+    error NotOwner();
+
     /// @dev initializes a new order book
     constructor() {
-        _transferOwnership(msg.sender);
+        _owner = msg.sender;
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        if (owner() != msg.sender) {
+            revert NotOwner();
+        }
+        _;
     }
 
     /// @dev changes the fee rate
@@ -29,7 +52,7 @@ contract OrderBook is Ownable, IOrderBook {
     /// @dev changes the owner of this order book
     function setOwner(address _newOwner) external onlyOwner {
         emit OwnerChanged(owner(), _newOwner);
-        _transferOwnership(_newOwner);
+        _owner = _newOwner;
     }
 
     /// @dev Creates a new sell order that can be easily indexed by something like theGraph.

--- a/src/SellOrder.sol
+++ b/src/SellOrder.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 import '@openzeppelin/contracts/access/Ownable.sol';
-import './OrderBook.sol';
+import './interfaces/IOrderBook.sol';
 
 contract SellOrder {
     /// @dev msg.sender is not the seller
@@ -46,7 +46,7 @@ contract SellOrder {
     uint256 public orderStake;
 
     /// @dev order book
-    OrderBook public orderBook;
+    address public orderBook;
 
     /// @dev the URI where metadata about this SellOrder can be found
     string private _uri;
@@ -76,14 +76,13 @@ contract SellOrder {
 
     /// @dev Creates a new sell order.
     constructor(
-        OrderBook orderBook_,
         address seller_,
         IERC20 token_,
         uint256 orderStake_,
         string memory uri_,
         uint256 timeout_
     ) {
-        orderBook = orderBook_;
+        orderBook = msg.sender;
         seller = seller_;
         token = token_;
         orderStake = orderStake_;
@@ -202,7 +201,8 @@ contract SellOrder {
         bool result1 = token.transfer(seller, orderStake);
         assert(result1);
 
-        uint256 toOrderBook = (offer.price * orderBook.fee()) / 1000000;
+        uint256 toOrderBook = (offer.price * IOrderBook(orderBook).fee()) /
+            1000000;
         uint256 toSeller = offer.price - toOrderBook;
 
         // Transfer payment to the seller

--- a/src/SellOrder.sol
+++ b/src/SellOrder.sol
@@ -210,7 +210,10 @@ contract SellOrder {
         assert(result2);
 
         // Transfer payment to the order book
-        bool result3 = token.transfer(address(orderBook), toOrderBook);
+        bool result3 = token.transfer(
+            IOrderBook(orderBook).owner(),
+            toOrderBook
+        );
         assert(result3);
 
         emit OfferConfirmed(msg.sender);

--- a/src/interfaces/IOrderBook.sol
+++ b/src/interfaces/IOrderBook.sol
@@ -11,6 +11,8 @@ interface IOrderBook {
 
     event FeeChanged(uint256 previous, uint256 next);
 
+    function owner() external view returns (address);
+
     function fee() external view returns (uint256);
 
     function setFee(uint256 _fee) external;

--- a/src/interfaces/IOrderBook.sol
+++ b/src/interfaces/IOrderBook.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import '../SellOrder.sol';
+
+interface IOrderBook {
+    event SellOrderCreated(address indexed sellOrder);
+
+    event OwnerChanged(address previous, address next);
+
+    event FeeChanged(uint256 previous, uint256 next);
+
+    function fee() external view returns (uint256);
+
+    function setFee(uint256 _fee) external;
+
+    function setOwner(address _newOwner) external;
+
+    function createSellOrder(
+        address seller,
+        IERC20 token,
+        uint256 stake,
+        string memory uri,
+        uint256 timeout
+    ) external returns (SellOrder);
+}

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -8,7 +8,7 @@ import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 import 'forge-std/console.sol';
 import '../src/OrderBook.sol';
 
-contract UnitTest is Test {
+contract SellOrderTest is Test {
     address DAO = address(0x4234567890123456784012345678901234567821);
     OrderBook book;
 
@@ -280,5 +280,41 @@ contract UnitTest is Test {
             token.balanceOf(seller) == 99 + 50,
             'seller did not get 1 token'
         );
+    }
+}
+
+contract OrderBookTest is Test {
+    function testFailOnlyOwnerCanSetFees() public {
+        address owner = address(0x1234567890123456784012345678901234567829);
+        vm.prank(owner);
+        OrderBook book = new OrderBook();
+        book.setFee(10);
+    }
+
+    function testFailOnlyOwnerCanSetOwner() public {
+        address owner = address(0x1234567890123456784012345678901234567829);
+        vm.prank(owner);
+        OrderBook book = new OrderBook();
+        book.setOwner(address(0x4234567890123456784012345678901234567822));
+    }
+
+    function testOwnerCanSetFees() public {
+        address owner = address(0x1234567890123456784012345678901234567829);
+        vm.prank(owner);
+        OrderBook book = new OrderBook();
+
+        vm.prank(owner);
+        book.setFee(10);
+        require(book.fee() == 10, 'fee is not 10');
+    }
+
+    function testOwnerCanSetOwner() public {
+        address owner = address(0x1234567890123456784012345678901234567829);
+        vm.prank(owner);
+        OrderBook book = new OrderBook();
+
+        vm.prank(owner);
+        book.setOwner(owner);
+        require(book.owner() == owner, 'owner is not owner');
     }
 }

--- a/test/Contract.t.sol
+++ b/test/Contract.t.sol
@@ -6,8 +6,11 @@ import './ERC20Mock.sol';
 import '../src/SellOrder.sol';
 import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 import 'forge-std/console.sol';
+import '../src/OrderBook.sol';
 
 contract UnitTest is Test {
+    OrderBook book = new OrderBook();
+
     function toSignature(
         uint8 v,
         bytes32 r,
@@ -18,7 +21,13 @@ contract UnitTest is Test {
 
     function testConstructor() public {
         ERC20Mock token = new ERC20Mock('wETH', 'WETH', address(this), 100);
-        SellOrder sellOrder = new SellOrder(token, 50, 'ipfs://', 100);
+        SellOrder sellOrder = book.createSellOrder(
+            address(this),
+            token,
+            50,
+            'ipfs://metadata',
+            100
+        );
 
         assert(address(sellOrder.token()) == address(token));
     }
@@ -32,8 +41,13 @@ contract UnitTest is Test {
         address buyer = address(0x5234567890123456754012345678901234567822);
 
         // Create a sell order
-        vm.prank(seller);
-        SellOrder sellOrder = new SellOrder(token, 50, 'ipfs://metadata', 100);
+        SellOrder sellOrder = book.createSellOrder(
+            seller,
+            token,
+            50,
+            'ipfs://metadata',
+            100
+        );
 
         token.transfer(buyer, 20);
         vm.startPrank(buyer);
@@ -78,8 +92,14 @@ contract UnitTest is Test {
         address seller = address(0x1234567890123456784012345678901234567829);
         address buyer = address(0x2234567890123456754012345678901234567821);
 
-        vm.prank(seller);
-        SellOrder sellOrder = new SellOrder(token, 50, 'ipfs://', 100);
+        // Create a sell order
+        SellOrder sellOrder = book.createSellOrder(
+            seller,
+            token,
+            50,
+            'ipfs://metadata',
+            100
+        );
 
         token.transfer(buyer, 20);
         vm.startPrank(buyer);
@@ -102,8 +122,13 @@ contract UnitTest is Test {
         address buyer2 = address(0x5234567890123456754012345678901234567822);
 
         // Create a sell order
-        vm.prank(seller);
-        SellOrder sellOrder = new SellOrder(token, 50, 'ipfs://metadata', 100);
+        SellOrder sellOrder = book.createSellOrder(
+            seller,
+            token,
+            50,
+            'ipfs://metadata',
+            100
+        );
 
         // Submit an offer from buyer1
         token.transfer(buyer1, 20);
@@ -173,8 +198,13 @@ contract UnitTest is Test {
         address seller = address(0x1234567890123456784012345678901234567829);
 
         // Create a sell order
-        vm.prank(seller);
-        SellOrder sellOrder = new SellOrder(token, 50, 'ipfs://metadata', 100);
+        SellOrder sellOrder = book.createSellOrder(
+            seller,
+            token,
+            50,
+            'ipfs://metadata',
+            100
+        );
 
         // Submit an offer from seller
         token.transfer(seller, 20);


### PR DESCRIPTION
# OrderBook

The OrderBook keeps track of all the SellOrders and acts as a decentralized aggregator. 

The OrderBook has an `owner`, which is expected to point to a DAO program, such as OpenZeppelin's [Governance](https://docs.openzeppelin.com/contracts/4.x/api/governance) modules. 

The OrderBook also has a configurable `fee` (a percentage in parts-per-million) that's used to pay for off-chain public goods, such as open source software packages, security auditors, client applications, or anything else the DAO wants. The DAO can also turn this fee off if it's no longer needed. 

## Usage 

In Solidity
```solidity
OrderBook book = new OrderBook();

// Emits SellOrderCreated(address sellOrder) event
book.createSellOrder(seller, token, stake, uri, timeout);
```


### Prior Art
- Uniswap (https://github.com/Uniswap/v3-core/blob/main/contracts/UniswapV3Factory.sol)
- LabDAO (https://github.com/labdao/openlab-contracts) 